### PR TITLE
Change sass_object_fetch_object to sass_fetch_object

### DIFF
--- a/src/sass.c
+++ b/src/sass.c
@@ -56,7 +56,7 @@ static inline sass_object *sass_fetch_object(zend_object *obj)
 
 static void sass_free_storage(zend_object *object)
 {
-    sass_object *obj = sass_object_fetch_object(object);
+    sass_object *obj = sass_fetch_object(object);
     if (obj->include_paths != NULL)
         efree(obj->include_paths);
 


### PR DESCRIPTION
Seems like a typo.

Fixes #11 

Similar commits:
https://github.com/pilif/sassphp/commit/fb496e7d7bc8b3a5adc7d2455afb09bcf14b32df
https://github.com/sensational/sassphp/commit/fcee2992570c6cf38e9bd46725028eb21df07c8f