### PR TITLE
Implement a better type system between libsass and PHP custom functions

### DIFF
--- a/src/php_sass.h
+++ b/src/php_sass.h
@@ -24,11 +24,18 @@
 
 #include <sass.h>
 #include <sass2scss.h>
+#include <sass/values.h>
 
 zend_class_entry *sass_ce;
 zend_class_entry *sass_exception_ce;
+zend_class_entry *sass_function_exception_ce;
+zend_class_entry *sass_value_exception_ce;
 
 zend_class_entry *sass_get_exception_base();
+
+int sass_value_resnum;
+
+static void sass_value_dtor(zend_resource *rsrc);
 
 #ifdef PHP_WIN32
 #define PHP_SASS_API __declspec(dllexport)
@@ -63,5 +70,16 @@ PHP_METHOD(Sass, getMapRoot);
 PHP_METHOD(Sass, setMapRoot);
 PHP_METHOD(Sass, setImporter);
 PHP_METHOD(Sass, setFunctions);
+
+PHP_FUNCTION(sass_make_null);
+PHP_FUNCTION(sass_make_boolean);
+PHP_FUNCTION(sass_make_string);
+PHP_FUNCTION(sass_make_qstring);
+PHP_FUNCTION(sass_make_number);
+PHP_FUNCTION(sass_make_color);
+PHP_FUNCTION(sass_make_list);
+PHP_FUNCTION(sass_make_map);
+PHP_FUNCTION(sass_make_error);
+PHP_FUNCTION(sass_make_warning);
 
 #endif

--- a/tests/custom_function.phpt
+++ b/tests/custom_function.phpt
@@ -8,12 +8,12 @@ custom importer: external file
 $sass = new Sass();
 $sass->setFunctions([
     'a($a)' => function($in, $path_info){
-        echo $in;
-        return "hello $in";
+        echo $in[0];
+        return sass_make_string("hello {$in[0]}");
     },
     'b($a)' => function($in, $path_info){
-        echo $in;
-        return "goodbye $in";
+        echo $in[0];
+        return sass_make_string("goodbye {$in[0]}");
     },
 ]);
 echo $sass->compile('body { content: a("foo"); } h1 { content: b("bar"); }');

--- a/tests/custom_function_arg_type_boolean.phpt
+++ b/tests/custom_function_arg_type_boolean.phpt
@@ -1,0 +1,19 @@
+--TEST--
+check callback argument type for boolean input
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        return sass_make_string(gettype($in[0]));
+    },
+]);
+echo $sass->compile('@debug a(true); @debug a(false);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: boolean
+stdin:1 DEBUG: boolean

--- a/tests/custom_function_arg_type_color.phpt
+++ b/tests/custom_function_arg_type_color.phpt
@@ -1,0 +1,19 @@
+--TEST--
+check callback argument type for color input
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        return sass_make_string(gettype($in[0]) . ',' . $in[0]);
+    },
+]);
+echo $sass->compile('@debug a(black); @debug a(rgba(128,64,192,0.5));');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: string,#000000
+stdin:1 DEBUG: string,#8040c07f

--- a/tests/custom_function_arg_type_list.phpt
+++ b/tests/custom_function_arg_type_list.phpt
@@ -1,0 +1,18 @@
+--TEST--
+check callback argument type for list input
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        return sass_make_string(implode('|', $in[0]));
+    },
+]);
+echo $sass->compile('@debug a(Helvetica Arial sans-serif);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: Helvetica|Arial|sans-serif

--- a/tests/custom_function_arg_type_map.phpt
+++ b/tests/custom_function_arg_type_map.phpt
@@ -1,0 +1,21 @@
+--TEST--
+check callback argument type for map input
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        $ktype = implode(',', array_map('gettype', array_keys($in[0])));
+        $vtype = implode(',', array_map('gettype', $in[0]));
+        $value = implode(',', array_map('strval', $in[0]));
+        return sass_make_string($ktype . ',' . $vtype . ',' . $value);
+    },
+]);
+echo $sass->compile('@debug a((0: true, 1px: false, test: blue));');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: integer,string,string,boolean,boolean,string,1,,#0000ff

--- a/tests/custom_function_arg_type_number.phpt
+++ b/tests/custom_function_arg_type_number.phpt
@@ -1,0 +1,19 @@
+--TEST--
+check callback argument type for number input
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        return sass_make_string(gettype($in[0]) . ',' . $in[0]);
+    },
+]);
+echo $sass->compile('@debug a(10.5); @debug a(10.5px);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: double,10.5
+stdin:1 DEBUG: string,10.5px

--- a/tests/custom_function_arg_type_string.phpt
+++ b/tests/custom_function_arg_type_string.phpt
@@ -1,0 +1,20 @@
+--TEST--
+check callback argument type for string input
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        return sass_make_string($in[0]);
+    },
+]);
+echo $sass->compile('@debug a(sample); @debug a(\'sample2\'); @debug a("sample3");');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: sample
+stdin:1 DEBUG: sample2
+stdin:1 DEBUG: sample3

--- a/tests/custom_function_make_boolean.phpt
+++ b/tests/custom_function_make_boolean.phpt
@@ -1,0 +1,22 @@
+--TEST--
+produce boolean from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        assert(gettype($in[0]) === 'boolean');
+        $retval = sass_make_boolean($in[0]);
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+echo $sass->compile('@debug a(true); @debug a(false);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: true
+stdin:1 DEBUG: false

--- a/tests/custom_function_make_color.phpt
+++ b/tests/custom_function_make_color.phpt
@@ -1,0 +1,21 @@
+--TEST--
+produce color from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        $retval = sass_make_color(10, 20, 30, $in[0] ? 0.4 : 1);
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+echo $sass->compile('@debug a(true); @debug a(false);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: rgba(10, 20, 30, 0.4)
+stdin:1 DEBUG: #0a141e

--- a/tests/custom_function_make_error.phpt
+++ b/tests/custom_function_make_error.phpt
@@ -1,0 +1,30 @@
+--TEST--
+produce error from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a()' => function(){
+        $retval = sass_make_error('error');
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+try {
+    echo $sass->compile('@debug a();');
+}
+catch (SassException $e)
+{
+    echo trim($e->getMessage()) . "\n";
+}
+
+?>
+--EXPECT--
+Error: error in C function a: error
+        on line 1:8 of stdin, in function `a`
+        from line 1:8 of stdin
+>> @debug a();
+   -------^

--- a/tests/custom_function_make_list.phpt
+++ b/tests/custom_function_make_list.phpt
@@ -1,0 +1,21 @@
+--TEST--
+produce list from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a, $b)' => function($in){
+        $retval = sass_make_list(array_map('sass_make_string', ['test', 'sample']), $in[0], $in[1]);
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+echo $sass->compile('@debug a(" ", false); @debug a(",", true);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: test sample
+stdin:1 DEBUG: [test, sample]

--- a/tests/custom_function_make_map.phpt
+++ b/tests/custom_function_make_map.phpt
@@ -1,0 +1,23 @@
+--TEST--
+produce map from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a()' => function(){
+        $retval = sass_make_map([
+            sass_make_string('test'),
+            'sample' => sass_make_boolean(false),
+        ]);
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+echo $sass->compile('@debug a();');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: (0: test, sample: false)

--- a/tests/custom_function_make_null.phpt
+++ b/tests/custom_function_make_null.phpt
@@ -1,0 +1,20 @@
+--TEST--
+produce null from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a()' => function(){
+        $retval = sass_make_null();
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+echo $sass->compile('@debug a();');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: null

--- a/tests/custom_function_make_number.phpt
+++ b/tests/custom_function_make_number.phpt
@@ -1,0 +1,22 @@
+--TEST--
+produce number (with optional unit) from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a, $b)' => function($in){
+        assert(gettype($in[0]) === 'double');
+        $retval = sass_make_number(intval($in[0]), $in[1] ? 'px' : '');
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+echo $sass->compile('@debug a(1.5, true); @debug a(2.5, false);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: 1px
+stdin:1 DEBUG: 2

--- a/tests/custom_function_make_qstring.phpt
+++ b/tests/custom_function_make_qstring.phpt
@@ -1,0 +1,21 @@
+--TEST--
+produce qstring from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        assert(gettype($in[0]) === 'double');
+        $retval = sass_make_qstring($in[0]);
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+echo $sass->compile('@debug a(1.5);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: 1.5

--- a/tests/custom_function_make_string.phpt
+++ b/tests/custom_function_make_string.phpt
@@ -1,0 +1,21 @@
+--TEST--
+produce string from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a($a)' => function($in){
+        assert(gettype($in[0]) === 'double');
+        $retval = sass_make_string($in[0]);
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+echo $sass->compile('@debug a(1.5);');
+
+?>
+--EXPECT--
+stdin:1 DEBUG: 1.5

--- a/tests/custom_function_make_warning.phpt
+++ b/tests/custom_function_make_warning.phpt
@@ -1,0 +1,30 @@
+--TEST--
+produce warning from callback
+--SKIPIF--
+<?php if (!extension_loaded("sass")) print "skip"; ?>
+--FILE--
+<?php
+
+$sass = new Sass();
+$sass->setFunctions([
+    'a()' => function(){
+        $retval = sass_make_warning('warning');
+        assert(get_resource_type($retval) === 'Sass_Value');
+        return $retval;
+    },
+]);
+try {
+    echo $sass->compile('@debug a();');
+}
+catch (SassException $e)
+{
+    echo trim($e->getMessage()) . "\n";
+}
+
+?>
+--EXPECT--
+Error: warning in C function a: warning
+        on line 1:8 of stdin, in function `a`
+        from line 1:8 of stdin
+>> @debug a();
+   -------^


### PR DESCRIPTION
I found the type support for custom functions to be a bit lacking, so I implemented better support for SASS values in PHP.

I updated the arguments sent to custom PHP functions to type-cast where appropriate (e.g. a SASS bool becomes a PHP bool) and picked a sane alternative for other types (e.g. a SASS color becomes a PHP string in the format `#AAAAAA` or `#AAAAAAAA`, a SASS number with unit is a string `10px` instead of a plain double).

Custom function return values must provide a resource that represents a `union Sass_Value*` under the hood; these can be constructed using the following API:

```php
/**
 * Creates a resource representing a `null` value in the SASS language.
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_null(): resource;

/**
 * Creates a resource representing a boolean value in the SASS language.
 *
 * @param bool $boolval
 *   The value that the resource should represent.
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_boolean(bool $boolval): resource;

/**
 * Creates a resource representing an unquoted string in the SASS language.
 *
 * @param string $str
 *   The string value that the resource should represent. This parameter is not
 *   binary-safe; NUL characters will mark the end of the string.
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_string(string $str): resource;

/**
 * Creates a resource representing a quoted string in the SASS language.
 *
 * @param string $str
 *   The string value that the resource should represent. This parameter is not
 *   binary-safe; NUL characters will mark the end of the string.
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_qstring(string $str): resource;

/**
 * Creates a resource representing a number in the SASS language.
 *
 * @param double $number
 *   The number value that the resource should represent.
 * @param string $unit
 *   The unit of the number (e.g. 'px' or 'deg').
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_number(double $number, string $unit = ''): resource;

/**
 * Creates a resource representing an RGB[A] color in the SASS language.
 *
 * @param double $r
 *   The value of the red channel (an int from [0, 255]).
 * @param double $g
 *   The value of the green channel (an int from [0, 255]).
 * @param double $b
 *   The value of the blue channel (an int from [0, 255]).
 * @param double $a
 *   The alpha channel of the color (decimal, [0, 1]; default: 1, fully-opaque).
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_color(double $r, double $g, double $b, double $a = 1): resource;

/**
 * Creates a resource representing a list in the SASS language.
 *
 * @param array $list
 *   An array of 'Sass_Value' resources.
 * @param string $separator
 *   The separator to use (can be a space " " or a comma ","; default: ' ').
 * @param bool $bracketed
 *   If the list should be surrounded by square brackets (default: FALSE).
 *
 * @throws \SassValueException
 *   If the separator is invalid or a non-Sass_Value resource was provided.
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_list(array $list, string $separator = ' ', bool $bracketed = FALSE): resource;

/**
 * Creates a resource representing a map in the SASS language.
 *
 * @param array $map
 *   An array of 'Sass_Value' resources. Keys can be either numbers or strings.
 *
 * @throws \SassValueException
 *   If a non-Sass_Value resource was provided.
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_map(array $map): resource;

/**
 * Creates a resource representing an error in the SASS language.
 *
 * @param string $message
 *   The message that the resource should contain. This parameter is not
 *   binary-safe; NUL characters will mark the end of the string.
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_error(string $message): resource;

/**
 * Creates a resource representing a warning in the SASS language.
 *
 * @param string $message
 *   The message that the resource should contain. This parameter is not
 *   binary-safe; NUL characters will mark the end of the string.
 *
 * @return resource
 *   A 'Sass_Value' resource for use in custom function return values.
 */
function sass_make_warning(string $message): resource;
```

Some notes for consideration by the reviewer:

1. `sass_make_map()` only supports numeric or string keys; this is a limitation in PHP. SASS (believe it or not) actually supports complex data structures (e.g. lists) as map keys.
2. `sass_make_warning()` isn't too useful as it still causes a `SassException`; this may be a limitation of how libsass handles these.
3. `sass_make_color()` can be inconvenient if you have a hexadecimal input; maybe we should have a `sass_make_color_hex()` too?

This is my first experience with writing for PHP extensions; please make sure that no memory leaks occur with my changes as the documentation for proper use of the Zend C macros is rather sparse.