### PR TITLE
Support NULL when converting Sass_Value to zval

### DIFF
--- a/src/sass.c
+++ b/src/sass.c
@@ -260,7 +260,9 @@ void sass_convert_to_zval(const sass_object* const obj, const union Sass_Value* 
                 }
             }
         } break;
-        default: break;
+        default: {
+            ZVAL_NULL(out);
+        } break;
     }
 }
 


### PR DESCRIPTION
`NULL` values are currently converted to `false` zvals. This PR should fix that.